### PR TITLE
docs: bootstrap installed-vs-source version parity check (reflection P2)

### DIFF
--- a/.claude/skills/syngen-bootstrap/SKILL.md
+++ b/.claude/skills/syngen-bootstrap/SKILL.md
@@ -105,6 +105,26 @@ APPROVAL REQUIRED: install missing module(s) <list> via
     "${PY}" -m pip install <list>
 ```
 
+### Step 2b — installed-vs-source version parity
+
+This library is consumed downstream by `tdm_syngen`, whose tests frequently run against this source tree via `PYTHONPATH=<syngen>/src` rather than an install. An **installed `syngen` wheel of a different version** then silently shadows or mismatches the source you are editing, producing failures (or false passes) that have nothing to do with your change. Before trusting any test result, compare the installed version to this source tree's `src/syngen/VERSION`:
+
+```bash
+"${PY}" - <<'PY'
+from importlib.metadata import version, PackageNotFoundError
+from pathlib import Path
+src = Path("src/syngen/VERSION").read_text().strip()
+try:
+    inst = version("syngen")
+except PackageNotFoundError:
+    inst = "(not installed)"
+print(f"source={src}  installed={inst}")
+print("MATCH" if inst == src else "DRIFT — prefer PYTHONPATH=<syngen>/src, or reinstall the matching wheel (escalation)")
+PY
+```
+
+On `DRIFT`, do **not** `pip install --upgrade` (denied by `.claude/settings.json` and a dependency change requiring escalation). Either run against the source tree with `PYTHONPATH` set, or escalate to reinstall the exact matching wheel. Report the drift in your handoff.
+
 ### Step 3 — verify pytest collection
 
 ```bash

--- a/docs/agent-harness/harness-changelog.md
+++ b/docs/agent-harness/harness-changelog.md
@@ -3,3 +3,4 @@
 | Date | File | Reason | Approved by |
 |------|------|--------|-------------|
 | 2026-05-27 | .claude/skills/syngen-implement-feature/SKILL.md | Add step 7: bump version in src/syngen/VERSION after each feature | human |
+| 2026-07-02 | .claude/skills/syngen-bootstrap/SKILL.md | Session-reflection P2 — add Step 2b installed-vs-source version parity check (`importlib.metadata.version("syngen")` vs `src/syngen/VERSION`); on DRIFT prefer PYTHONPATH=<syngen>/src or escalate a matching reinstall. Motivated by a session where a stale installed `syngen 0.10.45` shadowed a 0.12.x source tree during downstream tdm_syngen testing | human (`appchanges approved`) |


### PR DESCRIPTION
## Summary
Harness-only change from a review of past agent sessions. Adds a **Step 2b** to `syngen-bootstrap` that compares the installed `syngen` version (`importlib.metadata.version`) against this source tree's `src/syngen/VERSION`.

## Why
`tdm_syngen` runs its tests against this repo via `PYTHONPATH=<syngen>/src`. A stale installed `syngen` wheel of a different version silently shadows the source and produces failures unrelated to the change under test — a past session hit installed `0.10.45` vs `0.12.x` source. On `DRIFT` the skill directs the agent to use `PYTHONPATH` or escalate a matching reinstall (never `pip install --upgrade`, which is denied).

## Test plan
- [ ] Running the Step 2b snippet prints `source=<x> installed=<y>` and `MATCH`/`DRIFT` correctly.
- [ ] Docs/harness only — no library, CLI, or SDK behavior changed.

Made with [Cursor](https://cursor.com)